### PR TITLE
Rule linting

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ unit_testing ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ unit_testing ]
+    branches: [ '**' ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       working-directory: ./Src/CommandLine
       run: dotnet restore

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ $RECYCLE.BIN/
 
 /Src/CommandLine/CommandLine.VC.VC.opendb
 /Src/CommandLine/CommandLine.VC.db
+
+# vscode
+Src/Core/.vscode/

--- a/Src/CommandLine/CommandLineProgram.cs
+++ b/Src/CommandLine/CommandLineProgram.cs
@@ -210,6 +210,23 @@
                     }
                 }
             }
+
+            public void ResetPrintedError()
+            {
+                bool gotLock = false;
+                try
+                {
+                    printedErrLock.Enter(ref gotLock);
+                    printedErr = false;
+                }
+                finally
+                {
+                    if (gotLock)
+                    {
+                        printedErrLock.Exit();
+                    }
+                }
+            }
         }
     }
 }

--- a/Src/CommandLine/IMessageSink.cs
+++ b/Src/CommandLine/IMessageSink.cs
@@ -8,6 +8,8 @@
     {
         TextWriter Writer { get; }
 
+        void ResetPrintedError();
+
         void WriteMessage(string msg);
         
         void WriteMessage(string msg, SeverityKind severity);

--- a/Src/Core/API/Base/Constants.cs
+++ b/Src/Core/API/Base/Constants.cs
@@ -340,6 +340,8 @@
 
         public static readonly MessageString ProductivityWarning = new MessageString("Rule may construct any value accepted by constructor {0} at indices {1}", 48);
 
+        public static readonly MessageString NoBindingTypeError = new MessageString("Rule contains a variable {0} with no binding type. Types are not implicitly generated for variables. Example: x is Type.", 49);
+
         public struct MessageString
         {
             private string msg;

--- a/Src/Core/Common/Rules/CoreRule.cs
+++ b/Src/Core/Common/Rules/CoreRule.cs
@@ -2917,12 +2917,7 @@
 
                             return computed;
                         }
-                        else
-                        {
-                            throw new NotImplementedException();
-                        }
-
-                        return null;
+                        throw new NotImplementedException();
                     },
                     success);
 

--- a/Src/Core/Compiler/ActionSet.cs
+++ b/Src/Core/Compiler/ActionSet.cs
@@ -159,6 +159,18 @@
             TypeEnvironment bodyEnv;
             foreach (var b in bodies)
             {
+                string varName = null;
+                if(!RuleLinter.ValidateBodyQualifiedIds(b, out varName))
+                {
+                    var flag = new Flag(
+                    SeverityKind.Error,
+                    AST.Node,
+                    Constants.NoBindingTypeError.ToString(varName),
+                    Constants.NoBindingTypeError.Code);
+                    flags.Add(flag);
+                    return RecordValidationResult(false);
+                }
+
                 bodyEnv = TypeEnvironment.AddChild(b);
                 var cs = new ConstraintSystem(Index, b, bodyEnv, myComprData);
                 if (!cs.Validate(flags, varList, cancel))

--- a/Src/Core/Compiler/Linters/RuleLinter.cs
+++ b/Src/Core/Compiler/Linters/RuleLinter.cs
@@ -1,0 +1,73 @@
+namespace Microsoft.Formula.Compiler
+{
+    using System.Collections.Generic;
+
+    using API;
+    using API.Nodes;
+    using API.ASTQueries;
+
+    public sealed class RuleLinter
+    {
+        private static NodePred[] IdQueryRule = new NodePred[]
+        {
+            NodePredFactory.Instance.Star,
+            NodePredFactory.Instance.MkPredicate(NodeKind.Id) &
+            NodePredFactory.Instance.MkPredicate(ChildContextKind.Args)
+        };
+
+        private static NodePred[] DeclQueryRule = new NodePred[]
+        {
+            NodePredFactory.Instance.Star,
+            NodePredFactory.Instance.MkPredicate(NodeKind.Find)
+        };
+
+        public static bool ValidateBodyQualifiedIds(Body b, out string v)
+        {
+            var path = new LinkedList<ChildInfo>();
+            path.AddLast(new ChildInfo(b, ChildContextKind.AnyChildContext, -1, -1));
+
+            List<string> listOfVarIds = new List<string>();
+            b.FindAll(
+            path,
+            IdQueryRule, 
+            (ch, n) =>                
+            {
+                var id = (Id) n;
+                if(id.IsQualified)
+                {
+                    var v = id.Fragments[0];
+                    listOfVarIds.Add(v);
+                }
+            });
+
+            List<string> listOfBindingVars = new List<string>();
+            b.FindAll(
+            path,
+            DeclQueryRule, 
+            (ch, n) =>                
+            {
+                var find = (Find)n;
+                if(find.IsConstraint && 
+                   find.Binding != null &&
+                   find.Match.IsTypeTerm)
+                {
+                    string name = null;
+                    find.Binding.TryGetStringAttribute(AttributeKind.Name, out name);
+                    listOfBindingVars.Add(name);
+                }
+            });
+
+            foreach(var id in listOfVarIds)
+            {
+                if(!listOfBindingVars.Contains(id))
+                {
+                    v = id;
+                    return false;
+                }
+            }
+
+            v = null;
+            return true;
+        }
+    }
+}

--- a/Src/Core/Core.csproj
+++ b/Src/Core/Core.csproj
@@ -14,6 +14,9 @@
 
   <ItemGroup>
     <Compile Remove="Common\Terms\CanUnnDef.cs" />
+    <AssemblyAttribute Include="System.CLSCompliantAttribute">
+        <_Parameter1>false</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Core/Properties/AssemblyInfo.cs
+++ b/Src/Core/Properties/AssemblyInfo.cs
@@ -50,3 +50,5 @@ using System.Runtime.InteropServices;
                "cf20daab022f8ea79d62ec9b2b005f67925212d8580abe730c5135ed8788b5f4fe7f56f65acaa8" +
                "8f4711781c681c01c658746641cbef8a9216c1cdcc6b36b1eca2cfb6733af0714afc48a585cf0a" +
                "ba14c3dc")]
+
+[assembly: InternalsVisibleTo("Formula.Tests")]

--- a/Src/Core/Solver/Execution/SymExecuter.cs
+++ b/Src/Core/Solver/Execution/SymExecuter.cs
@@ -388,7 +388,6 @@
             if (hasConforms)
             {
                 var assumptions = new List<Z3Expr>();
-                Z3BoolExpr topLevelConstraint = null;
                 string pattern = @"conforms\d+$";
                 foreach (var elem in lfp)
                 {

--- a/Src/Tests/LintingTests.cs
+++ b/Src/Tests/LintingTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.IO;
+using Xunit;
+using Microsoft.Formula.CommandLine;
+using Microsoft.Formula.Compiler;
+using Microsoft.Formula.API.Nodes;
+using Microsoft.Formula.API;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    public class LintingTests : IClassFixture<CommandInterfaceFixture>
+    {
+        private readonly CommandInterfaceFixture _ciFixture;
+
+        public LintingTests(CommandInterfaceFixture fixture)
+        {
+            _ciFixture = fixture;
+        }
+
+        private void ResetStandardOutput()
+        {
+            var standardOutput = new StreamWriter(Console.OpenStandardOutput());
+            standardOutput.AutoFlush = true;
+            Console.SetOut(standardOutput);
+        }
+
+        private void CheckIfProgramLoaded()
+        {
+            _ciFixture._sink.ResetPrintedError();
+            using(StringWriter sw = new StringWriter())
+            using (_ciFixture._ci)
+            {
+                Console.SetOut(sw);
+
+                Assert.True(_ciFixture._ci.DoCommand("print"));
+
+                string output = sw.ToString();
+
+                ResetStandardOutput();
+
+                bool ctns = output.Contains("No file with that name");
+                if(!ctns)
+                {
+                    Assert.True(_ciFixture._ci.DoCommand("unload"));
+                }
+            }
+        }
+
+        [Fact]
+        public void TestRuleLinterFixedLoading()
+        {
+            using (_ciFixture._ci)
+            {
+                CheckIfProgramLoaded();
+                
+                string[] cmdPath = { "load", Path.GetFullPath("../../../models/weird_domain_fixed.4ml") };
+                Assert.True(_ciFixture._ci.DoCommand(String.Join(" ", cmdPath)));
+                Assert.False(_ciFixture._sink.PrintedError);
+            }
+        }
+
+        [Fact]
+        public void TestRuleLinterBrokenLoading()
+        {
+            using (_ciFixture._ci)
+            {
+                CheckIfProgramLoaded();
+                
+                string[] cmdPath = { "load", Path.GetFullPath("../../../models/weird_domain_broken.4ml") };
+                Assert.True(_ciFixture._ci.DoCommand(String.Join(" ", cmdPath)));
+                Assert.True(_ciFixture._sink.PrintedError);
+            }
+        }
+
+        [Fact]
+        public void TestValidRuleLinterValidateBodyQualifiedIds()
+        {
+            var body = Factory.Instance.MkBody();
+            var typeTerm = Factory.Instance.MkId("Node");
+            var varId = Factory.Instance.MkId("x");
+            var find = Factory.Instance.MkFind(varId, typeTerm);
+            body.Node.AddConstr(find.Node);
+
+            var nil = Factory.Instance.MkId("NIL");
+            var relConstr = Factory.Instance.MkRelConstr(RelKind.Neq, varId, nil);
+            body.Node.AddConstr(relConstr.Node);
+
+            string varName = "theta";
+            Assert.True(RuleLinter.ValidateBodyQualifiedIds(body.Node, out varName));
+            Assert.Null(varName);
+        }
+
+        [Fact]
+        public void TestValidRuleLinterValidateBodyNonQualifiedIds()
+        {
+            var body = Factory.Instance.MkBody();
+            var varId = Factory.Instance.MkId("x");
+            Assert.False(varId.Node.IsQualified);
+            var nil = Factory.Instance.MkId("NIL");
+            var relConstr = Factory.Instance.MkRelConstr(RelKind.Neq, varId, nil);
+            body.Node.AddConstr(relConstr.Node);
+
+            string varName = "theta";
+            Assert.True(RuleLinter.ValidateBodyQualifiedIds(body.Node, out varName));
+            Assert.Null(varName);
+        }
+
+        [Fact]
+        public void TestInvalidRuleLinterValidateBodyQualifiedIds()
+        {
+            var body = Factory.Instance.MkBody();
+            var varId = Factory.Instance.MkId("x.right");
+            Assert.True(varId.Node.IsQualified);
+            var nil = Factory.Instance.MkId("NIL");
+            var relConstr = Factory.Instance.MkRelConstr(RelKind.Neq, varId, nil);
+            body.Node.AddConstr(relConstr.Node);
+
+            string varName = "theta";
+            Assert.False(RuleLinter.ValidateBodyQualifiedIds(body.Node, out varName));
+            Assert.Equal("x", varName);
+        }
+    }
+
+    public class CommandInterfaceFixture : IDisposable
+    {
+        private readonly CommandLineProgram.ConsoleChooser _chooser;
+        public CommandLineProgram.ConsoleSink _sink;
+        public CommandInterface _ci { get; private set; }
+
+        public CommandInterfaceFixture()
+        {
+            _chooser = new CommandLineProgram.ConsoleChooser();
+            _sink = new CommandLineProgram.ConsoleSink();
+            _ci = new CommandInterface(_sink, _chooser);
+        }
+
+        public void Dispose()
+        {
+            _ci.Cancel();
+        }
+    }
+}

--- a/Src/Tests/Tests.csproj
+++ b/Src/Tests/Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-
+        <AssemblyName>Formula.Tests</AssemblyName>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Src/Tests/models/weird_domain_broken.4ml
+++ b/Src/Tests/models/weird_domain_broken.4ml
@@ -1,0 +1,21 @@
+domain AlgTrees
+{
+    Node ::= new (left: any Node + {NIL}, right: any Node + {NIL}).
+    Root ::= new (root: any Node).
+
+    height ::= (Node, Integer).
+    height(x,c) :- x.left = NIL, x.right = NIL, c = 0.
+    height(x,c) :- x.left = NIL, x.right != NIL, height(x.right,d), c = d+1.
+    height(x,c) :- x.right = NIL, x.left != NIL, height(x.left,d), c = d+1.
+    height(x,c) :- x.left != NIL, x.right != NIL, height(x.left,d), height(x.right,e), d >= e, c = d+1.
+    height(x,c) :- x.left != NIL, x.right != NIL, height(x.left,d), height(x.right,e), d < e, c = e+1.
+
+}
+
+model LessThanTwoLevels of AlgTrees
+{
+    node1 is Node(NIL,NIL).  
+    node2 is Node(node1, NIL).
+    node3 is Node(node2, NIL).
+    Root(node3).
+}

--- a/Src/Tests/models/weird_domain_fixed.4ml
+++ b/Src/Tests/models/weird_domain_fixed.4ml
@@ -1,0 +1,21 @@
+domain AlgTrees
+{
+    Node ::= new (left: any Node + {NIL}, right: any Node + {NIL}).
+    Root ::= new (root: any Node).
+
+    height ::= (Node, Integer).
+    height(x,c) :- x is Node, x.left = NIL, x.right = NIL, c = 0.
+    height(x,c) :- x is Node, x.left = NIL, x.right != NIL, height(x.right,d), c = d+1.
+    height(x,c) :- x is Node, x.right = NIL, x.left != NIL, height(x.left,d), c = d+1.
+    height(x,c) :- x is Node, x.left != NIL, x.right != NIL, height(x.left,d), height(x.right,e), d >= e, c = d+1.
+    height(x,c) :- x is Node, x.left != NIL, x.right != NIL, height(x.left,d), height(x.right,e), d < e, c = e+1.
+
+}
+
+model LessThanTwoLevels of AlgTrees
+{
+    node1 is Node(NIL,NIL).  
+    node2 is Node(node1, NIL).
+    node3 is Node(node2, NIL).
+    Root(node3).
+}


### PR DESCRIPTION
Added linting rules for checking required variable bindings to types. Added message for not binding variable to type error. Added linter tests for testing the linting rules. Added two models for testing the weird domain issue. Added tests to core assembly info to allow method usage. Fixed warning messages in core for unreachable code and unused variables. Image is error message and failed install when rule body has errors.

<img width="1027" alt="rule-linting" src="https://user-images.githubusercontent.com/8409466/184545915-ce00d4f3-53c1-421e-9df6-5df4b446cd0d.png">
.